### PR TITLE
Ruby 2.7: Add appuser service account

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,3 +33,8 @@ RUN curl -fsSL https://github.com/FreeTDS/freetds/archive/refs/tags/v${freetds_v
 # Misc tools
 # https://circleci.com/developer/orbs/orb/circleci/browser-tools
 RUN apt-get install -y --no-install-recommends gpg curl tar jq libasound2
+
+# create app user & home directory
+RUN adduser --uid 55555 --home /home/appuser --disabled-password --gecos "" appuser
+USER appuser
+WORKDIR /home/appuser


### PR DESCRIPTION
It's a general best practice to run as a non-root user. We can set that up by default here by creating a service account called `appuser`. Child images that need to install apt packages (etc) can switch with `USER root`, but otherwise the defaults will be following the best practice.