### PR TITLE
Link token file(s) from future bind mounts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,3 +37,6 @@ RUN apt-get install -y --no-install-recommends gpg curl tar jq libasound2
 # create app user & home directory
 RUN adduser --uid 55555 --home /home/appuser --disabled-password --gecos "" appuser
 WORKDIR /home/appuser
+
+# link future bind mount file(s) to their default location(s)
+RUN ln -s /mount/vault-shared/.vault-token /home/appuser/.vault-token


### PR DESCRIPTION
For apps that need these file(s), we can link them into the appuser home dir even before the bind mount exists. The container should be able to run fine even when the link target doesn't exist, such as when this image is used for CI, etc.