### PR TITLE
Add symlink for consul token file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ WORKDIR /home/appuser
 
 # link future bind mount file(s) to their default location(s)
 RUN ln -s /mount/vault-shared/.vault-token /home/appuser/.vault-token
+RUN ln -s /mount/vault-shared/.consul-token /home/appuser/.consul-token
 
 # add configuration files
 COPY --chown=appuser --chmod=0700 .docker/home ./


### PR DESCRIPTION
This is a followup to https://github.com/veracross/ruby-app-base/pull/7, to add a symlink for a provided .consul-token to the service account home dir