### PR TITLE
Enable bundler config for root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,3 +44,4 @@ RUN ln -s /mount/vault-shared/.consul-token /home/appuser/.consul-token
 
 # add configuration files
 COPY --chown=appuser --chmod=0700 .docker/home ./
+RUN ln -s /home/appuser/.bundle /root/.bundle


### PR DESCRIPTION
Prior to this change, running `bundle config` would show this:

```
$ docker run --rm -it veracross/ruby-app-base:ruby-2.7 bundle config
Settings are listed in order of priority. The top value will be used.
silence_root_warning
Set via BUNDLE_SILENCE_ROOT_WARNING: true

app_config
Set via BUNDLE_APP_CONFIG: "/usr/local/bundle"
```

No custom config! Missing deployment mode!

That's because the root user is the default user, and the bundler config is in appuser's home folder. Running as appuser shows the expected config.

We can make the conventional bundler config available for root as well by symlinking the bundler config for root:

```
$ docker run --rm -it veracross/ruby-app-base:bundler-config-for-root bundle config
Settings are listed in order of priority. The top value will be used.
deployment
Set for the current user (/root/.bundle/config): true

jobs
Set for the current user (/root/.bundle/config): 5

retry
Set for the current user (/root/.bundle/config): 5

silence_root_warning
Set via BUNDLE_SILENCE_ROOT_WARNING: true

app_config
Set via BUNDLE_APP_CONFIG: "/usr/local/bundle"
```

So putting this in the Dockerfile will fix this generally.

---

When this is approved & merged I'll copy the commit to the other Ruby version branches too.