### PR TITLE
Ruby 2.7: install bundler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,10 @@ RUN apt-get install -y --no-install-recommends gpg curl tar jq libasound2
 RUN adduser --uid 55555 --home /home/appuser --disabled-password --gecos "" appuser
 WORKDIR /home/appuser
 
+USER appuser
+RUN gem install bundler:2.4.22
+USER root
+
 # link future bind mount file(s) to their default location(s)
 RUN ln -s /mount/vault-shared/.vault-token /home/appuser/.vault-token
 RUN ln -s /mount/vault-shared/.consul-token /home/appuser/.consul-token


### PR DESCRIPTION
This PR preinstalls bundler into the image, which is the latest version for Ruby 2.7.

```
$ docker run --rm -it veracross/ruby-app-base:ruby-2.7-install-bundler bundler -v
Bundler version 2.4.22
```