### PR TITLE
Add post-push hook to retag the image

### DIFF
--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+if [[ "$PUSH_COMMIT_TIMESTAMP_TAG" == "true" ]]; then
+    COMMIT_TIMESTAMP_TAG="$SOURCE_BRANCH-${SOURCE_COMMIT:0:8}-$(date +%Y%m%d%H%M%S)"
+
+    docker tag $IMAGE_NAME $DOCKER_REPO:$COMMIT_TIMESTAMP_TAG
+    docker push $DOCKER_REPO:$COMMIT_TIMESTAMP_TAG
+fi


### PR DESCRIPTION
Per documentation (https://docs.docker.com/docker-hub/builds/advanced/) a hook file is how you can push multiple tags for an image build on Docker Hub.

This particular script pushes a branch tag w/ commit id and timestamp. Going forward, each commit on a branch will have it's own tag in addition to the branch tag. That extra tag will make it MUCH easier to revert tags if/when a commit is pushed that breaks an image.

The post-push hook only runs with docker hub build automation, but for additional safety `PUSH_COMMIT_TIMESTAMP_TAG` must be set to `true` (which I have also added as an env var to our build automation).

For example:

![image](https://github.com/veracross/ruby-app-base/assets/441085/2bbcf6a4-e182-4635-8c39-a4b7149c0826)

Once merged, I'll rebase all our ruby version branches on master to pick up the change. Then additional commits going forward will get tagged.